### PR TITLE
Add nuget.config for NuGet source configuration

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!-- Clear any inherited sources, then add nuget.org as the only source -->
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Include a nuget.config file to configure nuget.org as the sole package source.