### PR TITLE
Fixing Python path on devcontainer

### DIFF
--- a/src/csharp/McpAgentWorkshop.AppHost/Extensions.cs
+++ b/src/csharp/McpAgentWorkshop.AppHost/Extensions.cs
@@ -13,7 +13,7 @@ public static class Extensions
     static readonly string sourceFolder = Path.Combine(Environment.CurrentDirectory, "..", "..");
     static readonly string virtualEnvironmentPath = OperatingSystem.IsWindows() ?
         Path.Join(sourceFolder, "python", "workshop", ".venv") :
-        "/usr/local/python/current";
+        "/usr/local";
 
     public static IResourceBuilder<PythonAppResource> WithPostgres(this IResourceBuilder<PythonAppResource> builder, IResourceBuilder<IResourceWithConnectionString> db)
     {


### PR DESCRIPTION
Fixes #58

The bug was introduced by #47 because the Python install is now in a different location, since it's from the Docker image rather than a feature added - installed as root not user space.